### PR TITLE
Remove x-requested-with from non ajax request

### DIFF
--- a/src/PresenterTester.php
+++ b/src/PresenterTester.php
@@ -159,6 +159,9 @@ class PresenterTester
 			if ($request->isAjax()) {
 				$this->headers['x-requested-with'] = 'XMLHttpRequest';
 			}
+			else {
+				unset($this->headers['x-requested-with']);
+			}
 			$this->post = $request->getPost();
 			$this->url = $url;
 			$this->method = $request->getPost() ? 'POST' : 'GET';


### PR DESCRIPTION
Hi,

I found that if you once use TestPresenterRequest::withAjax() you don't have possibility make normal request anymore.
This is simple fix.