### PR TITLE
[WIP] added PresenterTester events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
 		"nette/application": "~2.4",
 		"nette/security": "~2.4",
 		"nette/forms": "~2.4",
+		"nette/utils": "~2.4",
 		"nette/tester": "~2.0"
 	},
 	"require-dev": {

--- a/src/PresenterTester.php
+++ b/src/PresenterTester.php
@@ -13,11 +13,24 @@ use Nette\Http\Request;
 use Nette\Http\Session;
 use Nette\Http\UrlScript;
 use Nette\Security\User;
+use Nette\SmartObject;
 use Tester\Assert;
 
 
+/**
+ * @method onApplicationRequestCreated(AppRequest $applicationRequest)
+ * @method onPresenterCreated(IPresenter $presenter)
+ */
 class PresenterTester
 {
+	use SmartObject;
+
+	/** @var callable[] */
+	public $onApplicationRequestCreated;
+
+	/** @var callable[] */
+	public $onPresenterCreated;
+
 	/** @var Session */
 	private $session;
 
@@ -68,7 +81,9 @@ class PresenterTester
 	public function execute(TestPresenterRequest $testRequest): TestPresenterResult
 	{
 		$applicationRequest = $this->createApplicationRequest($testRequest);
+		$this->onApplicationRequestCreated($applicationRequest);
 		$presenter = $this->createPresenter($testRequest);
+		$this->onPresenterCreated($presenter);
 		if ($applicationRequest->getMethod() === 'GET') {
 			$matchedRequest = $this->router->match($this->httpRequest);
 			PresenterAssert::assertRequestMatch($applicationRequest, $matchedRequest);


### PR DESCRIPTION
I added two events:
- `onApplicationRequestCreated`
- `onPresenterCreated`

For now, I tested with my application and it solves my problem, but I don't like the way it looks like:
```php
final class AdvertiserAffilFormPresenterTest extends TestCase
{
    /**
     * @var Application
     * @inject
     */
    public $application;

    /**
     * @var PresenterTester
     */
    private $presenterTester;

    public function __construct(PresenterTester $presenterTester)
    {
        $this->presenterTester = $presenterTester;
        $this->presenterTester->onPresenterCreated[] = function (IPresenter $presenter) {
            isset($presenter->checkSessionVersion) && $presenter->checkSessionVersion = FALSE;

            // Fix access to Presenter from Application - $application->getPresenter()
            $appReflection = new \ReflectionObject($this->application);
            $presenterProperty = $appReflection->getProperty('presenter');
            $presenterProperty->setAccessible(TRUE);
            $presenterProperty->setValue($this->application, $presenter);
        };
    }

    public function testActionDefault(IdentityProvider $identityProvider): void
    {
        $request = $this->presenterTester->createRequest(AdvertiserAdminExtension::MODULE . ':AdvertiserAffilForm')
            ->withParameters([
                'action' => 'default',
                'advertiserId' => '588',
            ])
            ->withIdentity($identityProvider->getAdminIdentity());

        $this->presenterTester->execute($request)
            ->assertRenders();
    }
}
```

- I don't like inject annotations, but don't know other way how to get `Container` or specific service for whole test case.
- I need to setup same thing in `onPresenterCreated` for every test case. I'd reather use shared setup for all test cases.
- I don't like injecting `IdentityProvider` to each test method. Most of the tests are for the admin section, it's repeated code. Would be nice if I could set identity globally. I did it in constructor before.

My old test cases looked like this:
```php
final class AdvertiserBannergenPresenterTest extends \Test\Libs\PresenterTestBase
{
    /**
     * @var Nette\Application\UI\Presenter
     */
    private $presenter;

    public function setUp(): void
    {
        $this->loginAdmin();
        $this->presenter = $this->createPresenter(AdvertiserAdminExtension::MODULE . ':AdvertiserBannergen');
    }

    public function testActionDefault(): void
    {
        $request = new Nette\Application\Request(AdvertiserAdminExtension::MODULE . ':AdvertiserBannergen', 'GET', [
            'action' => 'default',
            'advertiserId' => '1',
        ]);

        $response = $this->presenter->run($request);

        Assert::true($response instanceof Nette\Application\Responses\TextResponse);
        Assert::true($response->getSource() instanceof Nette\Application\UI\ITemplate);
    }
}
```

Any ideas?